### PR TITLE
configure.ac: bump version to 1.2.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([zlog], [1.2.7], [HardySimpson1984@gmail.com])
+AC_INIT([zlog], [1.2.12], [HardySimpson1984@gmail.com])
 AC_CONFIG_SRCDIR([src/version.h])
 AC_CONFIG_MACRO_DIR([m4])
 # Checks for programs.


### PR DESCRIPTION
Hello,

First, thank you for maintaining this repo!

I just noted that the version in the `configure.ac` file was not correct. Here is a quick patch to fix it :-)

Also, is it maybe possible to add git tags just like in HardySimpson's repo? At least for the latest 1.2.1 version? Because when checking the [releases](https://github.com/bmanojlovic/zlog/releases) section and the `configure.ac` file here on Github, I though this repo was no longer maintained.

Regards,
Matt
