### PR TITLE
Fix documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = doc src tools test
-dist_doc_DATA = COPYING INSTALL README TODO
+dist_doc_DATA = COPYING INSTALL README.md TODO
 EXTRA_DIST = autogen.sh

--- a/configure.ac
+++ b/configure.ac
@@ -21,8 +21,10 @@ AC_CHECK_LIB([pthread], [pthread_create])
 AC_CHECK_HEADERS([fcntl.h limits.h stdint.h stdlib.h string.h strings.h sys/time.h syslog.h unistd.h])
 
 # Checks for programs
-AM_CONDITIONAL([HAVE_LYX], [test "$(which lyx)" = "true"])
-AM_CONDITIONAL([HAVE_HEVEA], [test "$(which hevea)" = "true"])
+AC_CHECK_PROG([VAR_LYX], [lyx], [true], [false])
+AC_CHECK_PROG([VAR_HEVEA], [hevea], [true], [false])
+AM_CONDITIONAL([HAVE_LYX], [$VAR_LYX])
+AM_CONDITIONAL([HAVE_HEVEA], [$VAR_HEVEA])
 
 
 # Checks for typedefs, structures, and compiler characteristics.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,11 +1,8 @@
-dist_doc_DATA = GettingStart-CN.txt \
-	GettingStart-EN.txt \
-	performence.txt \
-	UsersGuide-CN.lyx \
-	UsersGuide-EN.lyx \
-	zlog.conf
-
 if HAVE_LYX
+LYX_PDFS = \
+  UsersGuide-EN.pdf \
+  UsersGuide-CN.pdf
+
 UsersGuide-EN.pdf : UsersGuide-EN.lyx
 	lyx -f -e pdf2 $^
 
@@ -17,7 +14,18 @@ UsersGuide-CN.pdf : UsersGuide-CN.lyx
 endif
 
 if HAVE_HEVEA
+LYX_HTML = \
+  UsersGuide-EN.html \
+  UsersGuide-CN.html
+
 %.html : %.tex
 	hevea book.hva -s $<
 	hevea book.hva -s $<
 endif
+
+dist_doc_DATA = GettingStart-CN.txt \
+	GettingStart-EN.txt \
+	performence.txt \
+	zlog.conf \
+	$(LYX_PDFS) \
+	$(LYX_HTML)


### PR DESCRIPTION
Installs the README.md file instead of README, and also generates .pdf and .html formats of the user guides when the necessary dependencies are installed.