### PR TITLE
Fix error of 'make check' in vpath mode

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,5 @@
 LDADD = $(top_builddir)/src/libzlog.la
-AM_CFLAGS = -I$(top_builddir)/src
+AM_CFLAGS = -I$(top_srcdir)/src
 test_level_SOURCES = test_level.c test_level.h
 check_PROGRAMS = test_bitmap \
 	test_buf \


### PR DESCRIPTION
Signed-off-by: Zhentao Huang <zhentao_huang@trendmicro.com>

### Platform
* Any

### Issue
Build the project in vpath mode. Reproduction steps list below:
1. enter project root
2. run `. ./autogen.sh` to produce `configure`
3. make directory `build`
4. enter directory `build`
5. run `../configure`
6. run `make check`

Get error
```
gcc -DPACKAGE_NAME=\"zlog\" -DPACKAGE_TARNAME=\"zlog\" -DPACKAGE_VERSION=\"1.2.7\" -DPACKAGE_STRING=\"zlog\ 1.2.7\" -DPACKAGE_BUGREPORT=\"HardySimpson1984@gmail.com\" -DPACKAGE_URL=\"\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DPACKAGE=\"zlog\" -DVERSION=\"1.2.7\" -DHAVE_LIBPTHREAD=1 -DHAVE_FCNTL_H=1 -DHAVE_LIMITS_H=1 -DHAVE_STDINT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_TIME_H=1 -DHAVE_SYSLOG_H=1 -DHAVE_UNISTD_H=1 -DHAVE_FORK=1 -DHAVE_VFORK=1 -DHAVE_WORKING_VFORK=1 -DHAVE_WORKING_FORK=1 -DLSTAT_FOLLOWS_SLASHED_SYMLINK=1 -DHAVE_STDLIB_H=1 -DHAVE_REALLOC=1 -DHAVE_ATEXIT=1 -DHAVE_GETHOSTNAME=1 -DHAVE_GETTIMEOFDAY=1 -DHAVE_LOCALTIME_R=1 -DHAVE_MEMMOVE=1 -DHAVE_MEMSET=1 -DHAVE_SETENV=1 -DHAVE_STRCHR=1 -DHAVE_STRRCHR=1 -DHAVE_STRTOL=1 -I. -I../../test    -I../src -g -O2 -c -o test_buf.o ../../test/test_buf.c
../../test/test_buf.c:10:10: fatal error: zc_defs.h: No such file or directory
 #include "zc_defs.h"
          ^~~~~~~~~~~
compilation terminated.
Makefile:534: recipe for target 'test_buf.o' failed
make[2]: *** [test_buf.o] Error 1
```

### Root Cause
In file `test/Makefile.am`, there's definition of `AM_CFLAGS=-I$(top_builddir)/src`. But header files can't be refered in `$(top_builddir)`

### Fix
Change `top_builddir` to `top_srcdir`